### PR TITLE
Fix: don't skip error if request body with non 200 status is empty

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -576,7 +576,15 @@ func handleErrStatus(res *http.Response) error {
 		}
 		defer reader.Close()
 
-		bytes, _ := ioutil.ReadAll(reader)
+		bytes, err := ioutil.ReadAll(reader)
+
+		if err != nil {
+			return err
+		}
+
+		if len(bytes) == 0 {
+			return errors.New("empty error body")
+		}
 
 		text := string(bytes)
 


### PR DESCRIPTION
We got an unhandled error on our production server in this part.

```
panic: runtime error: index out of range [0] with length 0

goroutine 72 [running]:
github.com/leprosus/golang-clickhouse.handleErrStatus(0xc003a5e6c0?)
        /home/akademic/projects/go/pkg/mod/github.com/leprosus/golang-clickhouse@v1.0.0/clickhouse.go:539 +0x24f
```