### PR TITLE
Fix: escape one single quotes `'` to `\'`, not two single quotes `''`

### DIFF
--- a/escape.go
+++ b/escape.go
@@ -6,7 +6,7 @@ func Escape(line string) string {
 
 	length := len(line)
 	for i := 0; i < length; i++ {
-		char := line[i: i+1]
+		char := line[i : i+1]
 
 		switch char {
 		case "\b":
@@ -19,7 +19,7 @@ func Escape(line string) string {
 			result += "\\n"
 		case "\t":
 			result += "\\t"
-		case `''`:
+		case `'`:
 			result += `\'`
 		case `\`:
 			result += `\\`
@@ -42,11 +42,11 @@ func Unescape(line string) string {
 	length := len(line)
 	for i := 0; i < length; i += 2 {
 		if i >= length-1 {
-			result += line[i: i+1]
+			result += line[i : i+1]
 			break
 		}
 
-		pair := line[i: i+2]
+		pair := line[i : i+2]
 
 		switch pair {
 		case "\\b":
@@ -68,7 +68,7 @@ func Unescape(line string) string {
 		case `\-`:
 			result += `-`
 		default:
-			result += line[i: i+1]
+			result += line[i : i+1]
 			i--
 		}
 	}


### PR DESCRIPTION
In the Clickhouse document at https://clickhouse.com/docs/en/sql-reference/syntax, the description for escaping single quotes in string literals is

> In string literals, you need to escape at least ' and \ using escape codes \' (or: '') and \\.

So we should escape one single quotes (`'`) to `\'`，not escape two single quotes (`''`) to `\'`

so 

````golang
case `''`:
````

should be 

````golang
case `'`:
````